### PR TITLE
Resolves issue #14 - Adicionar um alert de confirmação de exclusão 

### DIFF
--- a/public/assets/js/gitscrum.js
+++ b/public/assets/js/gitscrum.js
@@ -1,0 +1,25 @@
++function ($) {
+    'use strict';
+
+    $(document).on('click', '.form-delete .btn-submit-form', function (event) {
+        event.preventDefault();
+
+        var button = $(this);
+
+        swal({
+            title: "Are you sure about this?",
+            text: "You will not be able to recover this information!",
+            type: "warning",
+            showCancelButton: true,
+            confirmButtonColor: "#DD6B55",
+            confirmButtonText: "Yes, proceed!",
+            cancelButtonText: "No, cancel it!",
+            closeOnConfirm: true
+        }, function(isConfirm){
+            if (isConfirm) {
+                button.closest("form").submit();
+            }
+        });
+
+    });
+}(jQuery);

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -68,11 +68,13 @@
     <script src="/assets/js/plugins/chartJs/Chart.min.js"></script>
     <script src="/assets/js/plugins/sparkline/jquery.sparkline.min.js"></script>
 
+    <link rel="stylesheet" href="{{ asset('/assets/css/plugins/sweetalert/sweetalert.css') }}" />
+
 </head>
 
 <body class="top-navigation">
     <div id="wrapper">
-        <div id="page-wrapper" class="sidebar-content">
+        <div id="page-wrapper" @if ( Auth::check() ) class="sidebar-content" @endif>
 
             @if ( Auth::check() )
 
@@ -174,6 +176,8 @@
         $('.sparkpie').sparkline('html', { type: 'pie', height: '1.0em' });
     </script>
 
+    <script src="{{ asset('/assets/js/plugins/sweetalert/sweetalert.min.js')}}"></script>
+    <script src="{{ asset('/assets/js/gitscrum.js')}}"></script>
 </body>
 
 </html>

--- a/resources/views/sprints/show.blade.php
+++ b/resources/views/sprints/show.blade.php
@@ -21,7 +21,7 @@
                 <input type="hidden" name="_token" value="{{csrf_token()}}" />
                 <input type="hidden" name="_method" value="DELETE" />
                 <input type="hidden" name="slug" value="{{$sprint->slug}}" />
-                <button class="btn btn-sm btn-outline btn-primary font-bold" type="submit">
+                <button class="btn btn-sm btn-outline btn-primary font-bold btn-submit-form" type="submit">
                     <i class="fa fa-trash" aria-hidden="true"></i></a>
                 </button>
             </form>


### PR DESCRIPTION
Ao clicar em excluir um item é exibido uma mensagem de alerta de confirmação.

Inicialmente foi implementado somente na exclusão de sprints.

Foi criado um arquivo genérico e global.

Para exibir a mensagem de confirmação o form precisa ter a classe **form-delete** e o botão de submit ter a classe **btn-submit-form**. 

O botão de envio do form pode ser qualquer elemento que tenha a classe **btn-submit-form** e que esteja dentro do formulário.

### Funcionamento

O javascript captura todos os clicks de botões com a classe **btn-submit-form** dentro de forms com a classe **form-delete**. Caso o usuário clique em um desses botões é exibido automaticamente uma mensagem de confirmação da ação. Se o usuário clicar em cancelar nada acontece, se ele clicar em confirmar o javascript procura o elemento form mais próximo do botão e então envia o formulário.

O print abaixo ilustra como ficou a implementação.

![screen shot 2016-11-23 at 19 01 20](https://cloud.githubusercontent.com/assets/233643/20580391/c8c0ea28-b1b0-11e6-9cbe-447e5ef4360f.png)
