### PR TITLE
Fix issue #20 - Resolvido erro ao tentar fazer login com usuario sem …

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -44,6 +44,15 @@ class User extends Authenticatable
      */
     protected $casts = [];
 
+    public function setNameAttribute($value)
+    {
+        $this->attributes['name'] = $value;
+
+        if (empty($value)) {
+            $this->attributes['name'] = $this->attributes['username'];
+        }
+    }
+
     public function configStatuses()
     {
         return $this->belongsToMany(\GitScrum\Models\ConfigStatus::class, 'statuses', 'user_id', 'id');


### PR DESCRIPTION
Esse erro acontece quando uma pessoa que não preencheu o campo name no GitHub tenta fazer login na aplicação.

Como o sistema não pode bloquear o login só porque a pessoa não preencheu seu nome nas configurações do perfil do github, pode-se assumir então o nome da pessoa como o nome de usuário.

Feito a verificação para caso o nome do usuário do github venha vazio, caso esteja vazio é preenchido com o nickname.