### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Application description: gitscrum
 Authorization callback URL: http://URL/auth/github/callback
 ```
 Finally fill the informations in the .env file
-
+APP_URL=xxxxxxxxxxxx.xxx
 ```
 GITHUB_CLIENT_ID=XXXXX
 GITHUB_CLIENT_SECRET=XXXXXXXXXXXXXXXXXX


### PR DESCRIPTION
This little change in .env is required for github callback to work, might help others who didn't notice that the appurl is used by socialite to configure the callback.