### PR TITLE
Fixes issue #133 - Erro ao adicionar colaboradores com gitlab

### DIFF
--- a/app/Classes/Gitlab.php
+++ b/app/Classes/Gitlab.php
@@ -238,6 +238,7 @@ class Gitlab implements ProviderInterface
             if (isset($collaborator->id)) {
                 $data = [
                     'provider_id' => $collaborator->id,
+                    'provider' => 'gitlab',
                     'username' => $collaborator->username,
                     'name' => $collaborator->name,
                     'avatar' => $collaborator->avatar_url,


### PR DESCRIPTION
O problema é q na hora de salvar não estava sendo enviado o provider. Como o valor default do campo é "github", ele estava salvando com esse valor.