### PR TITLE
fix the unexpected {} error in the Wizzard controller

### DIFF
--- a/app/Http/Controllers/WizardController.php
+++ b/app/Http/Controllers/WizardController.php
@@ -9,7 +9,9 @@
 namespace GitScrum\Http\Controllers;
 
 use GitScrum\Models\ProductBacklog;
-use {Request,Session,Auth};
+use Request;
+use Session;
+use Auth;
 
 class WizardController extends Controller
 {


### PR DESCRIPTION
When performing an installation clean up and receive the following error:

FatalThrowableError in WizardController.php line 12:
Parse error: syntax error, unexpected '{', expecting identifier (T_STRING) or function (T_FUNCTION) or const (T_CONST) or \\ (T_NS_SEPARATOR)

The problem is found in the WizzardController driver since it uses brackets to import the Request, Session and Auth classes which causes the error.

Environment:
Laravel Forge
PHP 7.1
Nginx
