### PR TITLE
Nginx instead of Apache

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - MYSQL_PASSWORD=gitscrum
 
   web:
-    image: ambientum/php:7.0-apache
+    image: ambientum/php:7.1-nginx
     container_name: gitscrum-web
     volumes:
       - .:/var/www/app


### PR DESCRIPTION
Hi @renatomarinho,

Nginx image is more tested and reliable than Apache one, also, 7.1 stable.