### PR TITLE
Fixed carbon causing error when null

### DIFF
--- a/resources/views/partials/lists/sprints.blade.php
+++ b/resources/views/partials/lists/sprints.blade.php
@@ -18,38 +18,31 @@
     @endif
 
     @if(!isset($list->column) || in_array('tbody_sprintBacklog', $list->column))
-
-    <td>
-        <a href="{{route('sprints.show', ['slug'=>$list->slug])}}">
-            {{$list->title}}
-        </a>
-        <div class="details">
-
-            @include('partials.boxes.progress-bar', [ 'percentage' => Helper::percentage($list, 'issues')])
-
-            <span>
-                <strong>{{trans('gitscrum.timebox')}}:</strong>
-
-                {{$list->timebox}} ( {{ $list->weeks()->count() }} {{ str_plural(trans('gitscrum.week'), $list->weeks()->count()) }})
-
-            </span>
-
-            <span>
-                <strong>{{trans('gitscrum.issues')}}:</strong> {{$list->issues->where('closed_at', NULL)->count()}}
-                {{trans('gitscrum.open')}} /
-                {{$list->issues->where('closed_at', '!=', NULL)->count()}} {{trans('gitscrum.closed')}}
-            </span>
-        </div>
-    </td>
-
+        <td>
+            <a href="{{route('sprints.show', ['slug'=>$list->slug])}}">
+                {{$list->title}}
+            </a>
+            <div class="details">
+                @include('partials.boxes.progress-bar', [ 'percentage' => Helper::percentage($list, 'issues')])
+                <span>
+                    <strong>{{trans('gitscrum.timebox')}}:</strong>
+                    {{$list->timebox}} ( {{ $list->scopeWeeks(date('Y-m-d')) }} {{ str_plural(trans('gitscrum.week'), $list->scopeWeeks(date('Y-m-d'))) }})
+                </span>
+                <span>
+                    <strong>{{trans('gitscrum.issues')}}:</strong> {{$list->issues->where('closed_at', NULL)->count()}}
+                    {{trans('gitscrum.open')}} /
+                    {{$list->issues->where('closed_at', '!=', NULL)->count()}} {{trans('gitscrum.closed')}}
+                </span>
+            </div>
+        </td>
     @endif
 
     @if(!isset($list->column) || in_array('tbody_sprintProductBacklog', $list->column))
-    <td class="text-right">
-        <a href="{{route('product_backlogs.show', ['slug'=>$list->productBacklog->slug])}}" class="text-middle btn btn-link">
-            {{$list->productBacklog->title}}
-        </a>
-    </td>
+        <td class="text-right">
+            <a href="{{route('product_backlogs.show', ['slug'=>$list->productBacklog->slug])}}" class="text-middle btn btn-link">
+                {{$list->productBacklog->title}}
+            </a>
+        </td>
     @endif
 
 </tr>

--- a/resources/views/partials/lists/sprints.blade.php
+++ b/resources/views/partials/lists/sprints.blade.php
@@ -1,36 +1,55 @@
 <tr>
 
     @if(!isset($list->column) || in_array('tbody_sprintFavorite', $list->column))
-    <td>@include('partials.lnk-favorite', ['favorite' => $list->favorite, 'type' => 'sprints',
-        'id' => $list->id, 'btnSize' => 'btn-xs'])</td>
+        <td>
+            @include('partials.lnk-favorite', ['favorite' => $list->favorite, 'type' => 'sprints', 'id' => $list->id, 'btnSize' => 'btn-xs'])
+        </td>
     @endif
 
     @if(!isset($list->column) || in_array('tbody_sprintLabels', $list->column))
-    <td>
-        <span class="label label-default">{{$list->visibility}}</span>
-        <span class="label label-primary" style="background-color:#{{$list->status->color}};">
-            {{$list->status->title}}</span></td>
+        <td>
+            <span class="label label-default">
+                {{$list->visibility}}
+            </span>
+            <span class="label label-primary" style="background-color:#{{$list->status->color}};">
+                {{$list->status->title}}
+            </span>
+        </td>
     @endif
 
     @if(!isset($list->column) || in_array('tbody_sprintBacklog', $list->column))
+
     <td>
-        <a href="{{route('sprints.show', ['slug'=>$list->slug])}}">{{$list->title}}</a>
+        <a href="{{route('sprints.show', ['slug'=>$list->slug])}}">
+            {{$list->title}}
+        </a>
         <div class="details">
+
             @include('partials.boxes.progress-bar', [ 'percentage' => Helper::percentage($list, 'issues')])
-            <span><strong>{{trans('gitscrum.timebox')}}:</strong> {{$list->timebox}} ({{$list->weeks()}} {{str_plural
-            ( trans('gitscrum.week') ,
-            $list->weeks())}})</span>
-            <span><strong>{{trans('gitscrum.issues')}}:</strong> {{$list->issues->where('closed_at', NULL)->count()}}
+
+            <span>
+                <strong>{{trans('gitscrum.timebox')}}:</strong>
+
+                {{$list->timebox}} ( {{ $list->weeks()->count() }} {{ str_plural(trans('gitscrum.week'), $list->weeks()->count()) }})
+
+            </span>
+
+            <span>
+                <strong>{{trans('gitscrum.issues')}}:</strong> {{$list->issues->where('closed_at', NULL)->count()}}
                 {{trans('gitscrum.open')}} /
-            {{$list->issues->where('closed_at', '!=', NULL)->count()}} {{trans('gitscrum.closed')}}</span>
+                {{$list->issues->where('closed_at', '!=', NULL)->count()}} {{trans('gitscrum.closed')}}
+            </span>
         </div>
     </td>
+
     @endif
 
     @if(!isset($list->column) || in_array('tbody_sprintProductBacklog', $list->column))
-    <td class="text-right"><a href="{{route('product_backlogs.show', ['slug'=>$list->productBacklog->slug])}}"
-        class="text-middle">
-        {{$list->productBacklog->title}}</span></td>
+    <td class="text-right">
+        <a href="{{route('product_backlogs.show', ['slug'=>$list->productBacklog->slug])}}" class="text-middle btn btn-link">
+            {{$list->productBacklog->title}}
+        </a>
+    </td>
     @endif
 
 </tr>

--- a/resources/views/sprints/show.blade.php
+++ b/resources/views/sprints/show.blade.php
@@ -105,9 +105,9 @@
 
         <h4>{{trans('gitscrum.date')}}: {{$sprint->date_start}} {{trans('gitscrum.to')}} {{$sprint->date_finish}}</h4>
 
-        <p>{{$sprint->workingDays(date('Y-m-d'))}} {{trans('gitscrum.missing-day')}} /
-            {{$sprint->workingDays()}} {{trans('gitscrum.workdays')}}
-            ( {{$sprint->weeks()}} {{trans('gitscrum.week')}} )</p>
+        <p>{{$sprint->scopeWorkingDays(date('Y-m-d'))}} {{trans('gitscrum.missing-day')}} /
+            {{$sprint->scopeWorkingDays(date('Y-m-d'))}} {{trans('gitscrum.workdays')}}
+            ( {{$sprint->scopeWeeks(date('Y-m-d'))}} {{trans('gitscrum.week')}} )</p>
 
         <p class="">
             {{trans('gitscrum.product-backlog')}}: <a href="{{route('product_backlogs.show', ['slug' =>


### PR DESCRIPTION
Fixed issue with query related to carbon receiving null results in `sprints.blade.php` and in `show.blade.php`

This resolves further reported errors in ticket #193 