### PR TITLE
fix missing product backlog slug

### DIFF
--- a/resources/views/product_backlogs/show.blade.php
+++ b/resources/views/product_backlogs/show.blade.php
@@ -24,7 +24,7 @@
 @section('content')
 <div class="col-lg-4">
 
-    <a href="{{route('user_stories.create')}}"
+    <a href="{{route('user_stories.create', ['slug_product_backlog' => $productBacklog->slug])}}"
         class="btn btn-block btn-primary"
         data-toggle="modal" data-target="#modalLarge">{{trans('gitscrum.create-user-story')}}</a>
     <a href="{{route('sprints.create', ['slug_product_backlog' => $productBacklog->slug])}}"


### PR DESCRIPTION
in product backlog detail, when we want to create new user story the current product backlog is not default selected because there is missing slug parameter. This PR is to fixed current issue.