### PR TITLE
Included validation to avoid create issues without an sprint assignation

### DIFF
--- a/app/Http/Requests/IssueRequest.php
+++ b/app/Http/Requests/IssueRequest.php
@@ -32,6 +32,7 @@ class IssueRequest extends FormRequest
     {
         return [
             'title' => 'required|min:2|max:255',
+            'sprint_id' => 'required|integer',
         ];
     }
     /**
@@ -45,6 +46,7 @@ class IssueRequest extends FormRequest
             'title.required' => trans('gitscrum.issue-cannot-be-blank'),
             'title.min' => trans('gitscrum.issue-must-be-at-least-2-characters'),
             'title.max' => trans('gitscrum.issue-must-be-between-2-and-255-characters'),
+            'sprint_id.required' => trans('gitscrum.sprint-cannot-be-blank'),
         ];
     }
 

--- a/resources/lang/en/gitscrum.php
+++ b/resources/lang/en/gitscrum.php
@@ -6,7 +6,7 @@
  * The MIT License (MIT)
  * Copyright (c) 2017 Renato Marinho <renato.marinho@s2move.com>
  */
-return array (
+return array (
   'sprints' => 'Sprints',
   'issue-type' => 'Issue Type',
   'search-issue-type-by-name...' => 'Search issue type by name...',
@@ -187,4 +187,5 @@
   'congratulations-the-product-backlog-has-been-updated-with-successfully' => 'Congratulations! The Product Backlog has been successfully updated',
   'favorited-successfully' => 'Favorited',
   'unfavorited-successfully' => 'Unfavorited',
+  'sprint-cannot-be-blank' => 'Sprint can not be blank',
 );

--- a/resources/lang/es/gitscrum.php
+++ b/resources/lang/es/gitscrum.php
@@ -6,7 +6,7 @@
  * The MIT License (MIT)
  * Copyright (c) 2017 Renato Marinho <renato.marinho@s2move.com>
  */
-return array (
+return array (
   'sprints' => 'Sprints',
   'issue-type' => 'Tipo de issue',
   'search-issue-type-by-name...' => 'Buscar un issue por su nombre...',
@@ -17,7 +17,7 @@
   'labels' => 'Etiquetas',
   'label' => 'Etiqueta',
   'profile' => 'Perfil',
-  'cooperation' => 'Coopración',
+  'cooperation' => 'Cooperación',
   'issues-done' => 'Issues completados',
   'commits' => 'Commits',
   'dashboard' => 'Panel de control',
@@ -188,4 +188,5 @@
   'congratulations-the-product-backlog-has-been-updated-with-successfully' => '¡Felicidades! El product backlog ha sido actualizado correctamente',
   'favorited-successfully' => 'Añadido a favoritos correctamente',
   'unfavorited-successfully' => 'Eliminado de favoritos correctamente',
+  'sprint-cannot-be-blank' => 'El sprint no puede quedar vacío',
 );


### PR DESCRIPTION
This validation avoid an error when the user try access to Issues Type clicking the badges like `UX`, `New Feature`, etc., also I included spanish and english translations

![image](https://user-images.githubusercontent.com/6268687/30499204-2de01a26-9a1f-11e7-91f2-c79ba40f840d.png)
